### PR TITLE
Fix regression of aws3v4ugprade filter

### DIFF
--- a/filter/awsv4upgrade/all.go
+++ b/filter/awsv4upgrade/all.go
@@ -13,7 +13,7 @@ type AllFilter struct {
 
 var _ editor.Filter = (*AllFilter)(nil)
 
-// AllFilter creates a new instance of AllFilter.
+// NewAllFilter creates a new instance of AllFilter.
 func NewAllFilter() editor.Filter {
 	return &AllFilter{}
 }
@@ -22,7 +22,7 @@ func NewAllFilter() editor.Filter {
 // Only aws_s3_bucket refactor is supported.
 func (f *AllFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
 	m := editor.NewMultiFilter([]editor.Filter{
-		&AWSS3BucketFilter{},
+		NewAWSS3BucketFilter(),
 	})
 	return m.Filter(inFile)
 }


### PR DESCRIPTION
I wasn't aware of that the initialization from the CLI was broken because I implemented individual rules and checked them in unit tests.

The cause of the bug was the change:
https://github.com/minamijoyo/tfedit/commit/6d79f105bde130772345b9b48be32d86cf817972

I'll add acceptance tests for CLI later.