### PR TITLE
Use a top-level object_lock_enabled for object_lock_configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Known limitations:
       - date = "2022-12-31" => date = "2022-12-31T00:00:00Z"
     - expiration:
       - date = "2022-12-31" => date = "2022-12-31T00:00:00Z"
+  - object_lock_configuration:
+    - object_lock_configuration.object_lock_enabled = "Enabled" => object_lock_enabled = true
   - versioning:
     - enabled = true => status = "Enabled"
     - enabled = false => It also depends on the current status of your bucket. Set `status = "Suspended"` or use `for_each` to avoid creating `aws_s3_bucket_versioning` resource.

--- a/filter/awsv4upgrade/aws_s3_bucket_object_lock_configuration.go
+++ b/filter/awsv4upgrade/aws_s3_bucket_object_lock_configuration.go
@@ -3,6 +3,7 @@ package awsv4upgrade
 import (
 	"github.com/minamijoyo/tfedit/tfeditor"
 	"github.com/minamijoyo/tfedit/tfwrite"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // AWSS3BucketObjectLockConfigurationFilter is a filter implementation for
@@ -40,8 +41,30 @@ func (f *AWSS3BucketObjectLockConfigurationFilter) ResourceFilter(inFile *tfwrit
 	ruleBlocks := objectLockBlock.FindNestedBlocksByType("rule")
 	for _, ruleBlock := range ruleBlocks {
 		newResource.AppendNestedBlock(ruleBlock)
-		objectLockBlock.RemoveNestedBlock(ruleBlock)
 	}
+
+	// Map an `object_lock_configuration.object_lock_enabled` attribute
+	// to a top-level `object_lock_enabled` attribute.
+	// In addition, the valid type is now bool.
+	// object_lock_enabled = "Enabled" => true
+	enabledAttr := objectLockBlock.GetAttribute("object_lock_enabled")
+	if enabledAttr != nil {
+		enabled, err := enabledAttr.ValueAsString()
+		if err == nil {
+			switch enabled {
+			case `"Enabled"`:
+				resource.SetAttributeValue("object_lock_enabled", cty.BoolVal(true))
+			// case `"Disabled"`:
+			// "Disabled" is not defined as an old valid value.
+			// The top-level `object_lock_enabled` attribute is optional and the default is false. No op.
+			default:
+				// If the value is a variable, not literal, we cannot rewrite it automatically.
+				// Set original raw tokens as it is.
+				resource.SetAttributeRaw("object_lock_enabled", enabledAttr.ValueAsTokens())
+			}
+		}
+	}
+	resource.RemoveNestedBlock(objectLockBlock)
 
 	return inFile, nil
 }

--- a/filter/awsv4upgrade/aws_s3_bucket_object_lock_configuration_test.go
+++ b/filter/awsv4upgrade/aws_s3_bucket_object_lock_configuration_test.go
@@ -38,10 +38,7 @@ resource "aws_s3_bucket" "example" {
 resource "aws_s3_bucket" "example" {
   bucket = "tfedit-test"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_object_lock_configuration" "example" {

--- a/filter/awsv4upgrade/aws_s3_bucket_test.go
+++ b/filter/awsv4upgrade/aws_s3_bucket_test.go
@@ -256,10 +256,7 @@ EOF
 resource "aws_s3_bucket" "example" {
   bucket = "tfedit-test"
 
-  object_lock_configuration {
-    object_lock_enabled = "Enabled"
-
-  }
+  object_lock_enabled = true
 }
 
 resource "aws_s3_bucket_accelerate_configuration" "example" {


### PR DESCRIPTION
Starting from AWS provider v4.5.0, an `object_lock_configuration` block in the `aws_s3_bucket` resource is now deprecated and an `object_lock_enabled` attribute inside the `object_lock_configuration` block was moved to a top-level.
https://github.com/hashicorp/terraform-provider-aws/pull/23556