### PR TITLE
Map `mfa_delete` true/false => Enabled/Disabled for aws_s3_bucket_versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ For upgrading AWS provider v4, some rules have not been implemented yet. The cur
   - versioning:
     - enabled = true => status = "Enabled"
     - enabled = false => It also depends on the current status of your bucket. Set `status = "Suspended"` or use `for_each` to avoid creating `aws_s3_bucket_versioning` resource.
+    - mfa_delete = true => mfa_delete = "Enabled"
+    - mfa_delete = false => mfa_delete = "Disabled"
 - Some arguments cannot be converted correctly without knowing the current state of AWS resources. The tfedit never calls the AWS API on your behalf. You have to check it by yourself. The following arguments have this limitation:
   - grant:
     - owner: A [grant](https://registry.terraform.io/providers/hashicorp/aws/3.74.3/docs/resources/s3_bucket#grant) argument of aws_s3_bucket in v3 doesn’t have an owner block, but an access_control_policy argument of aws_s3_bucket_acl in v4 has an [owner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl#access_control_policy) block as required. There is no way to set it automatically without the AWS API call. You need to set the owner by yourself. You can get your AWS canonical user id with [`aws s3api get-bucket-acl --bucket <bucketname>`](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/get-bucket-acl.html) or use [aws_canonical_user_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) data source.

--- a/filter/awsv4upgrade/aws_s3_bucket_versioning_test.go
+++ b/filter/awsv4upgrade/aws_s3_bucket_versioning_test.go
@@ -112,6 +112,64 @@ resource "aws_s3_bucket" "example" {
 }
 `,
 		},
+		{
+			name: "mfa_delete = true",
+			src: `
+resource "aws_s3_bucket" "example" {
+  bucket = "tfedit-test"
+
+  versioning {
+    enabled    = true
+    mfa_delete = true
+  }
+}
+`,
+			ok: true,
+			want: `
+resource "aws_s3_bucket" "example" {
+  bucket = "tfedit-test"
+
+}
+
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.example.id
+
+  versioning_configuration {
+    mfa_delete = "Enabled"
+    status     = "Enabled"
+  }
+}
+`,
+		},
+		{
+			name: "mfa_delete = false",
+			src: `
+resource "aws_s3_bucket" "example" {
+  bucket = "tfedit-test"
+
+  versioning {
+    enabled    = true
+    mfa_delete = false
+  }
+}
+`,
+			ok: true,
+			want: `
+resource "aws_s3_bucket" "example" {
+  bucket = "tfedit-test"
+
+}
+
+resource "aws_s3_bucket_versioning" "example" {
+  bucket = aws_s3_bucket.example.id
+
+  versioning_configuration {
+    mfa_delete = "Disabled"
+    status     = "Enabled"
+  }
+}
+`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #40

Note that there is also the mfa argument in v4, but it seems practically meaningless. Simply ignore it.