### PR TITLE
Suppress creating a migration file when no action

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -82,6 +82,15 @@ func runMigrationFromplanCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Suppress creating a migration file when no action.
+	// It is not only redundant, but also causes an error as an invalid migration
+	// file when loaded by tfmigrate.
+	if len(output) == 0 {
+		// Intentionally does not return errors so that we can simply ignore
+		// irrelevant directories when processing multiple directories.
+		return nil
+	}
+
 	if migrationFile == "-" {
 		fmt.Fprint(cmd.OutOrStdout(), string(output))
 	} else {

--- a/migration/state_migration.go
+++ b/migration/state_migration.go
@@ -46,7 +46,8 @@ func (m *StateMigration) AppendActions(actions ...StateAction) {
 	m.Actions = append(m.Actions, actions...)
 }
 
-// Render converts a state migration config to bytes
+// Render converts a state migration config to bytes.
+// Return an empty slice when no action without error.
 // Encoding StateMigratorConfig directly with gohcl has some problems.
 // An array contains multiple elements is output as one line. It's not readable
 // for multiple actions. In additon, the default value is set explicitly, it's
@@ -54,6 +55,11 @@ func (m *StateMigration) AppendActions(actions ...StateAction) {
 // familiar with tfmigrate.
 // So we use text/template to render a migration file.
 func (m *StateMigration) Render() ([]byte, error) {
+	// Return an empty slice when no action without error.
+	if len(m.Actions) == 0 {
+		return []byte{}, nil
+	}
+
 	var output bytes.Buffer
 	if err := compiledMigrationTemplate.Execute(&output, m); err != nil {
 		return nil, fmt.Errorf("failed to render migration file: %s", err)

--- a/migration/state_migration_test.go
+++ b/migration/state_migration_test.go
@@ -40,6 +40,14 @@ func TestStateMigrationRender(t *testing.T) {
 `,
 		},
 		{
+			desc:    "empty",
+			name:    "mytest",
+			dir:     "",
+			actions: []StateAction{},
+			ok:      true,
+			want:    "",
+		},
+		{
 			desc: "simple with dir",
 			name: "mytest",
 			dir:  "tmp/dir1",


### PR DESCRIPTION
Fixes #33

It is not only redundant but also causes an error as an invalid migration file when loaded by tfmigrate.
Intentionally does not return errors, so we can ignore irrelevant directories when processing multiple directories.