### PR TITLE
Suppress adding invalid days_after_initiation for aws_s3_bucket_lifecycle_configuration

### DIFF
--- a/filter/awsv4upgrade/aws_s3_bucket_lifecycle_rule.go
+++ b/filter/awsv4upgrade/aws_s3_bucket_lifecycle_rule.go
@@ -191,9 +191,14 @@ func (f *AWSS3BucketLifecycleRuleFilter) ResourceFilter(inFile *tfwrite.File, re
 		// }
 		abortAttr := nestedBlock.GetAttribute("abort_incomplete_multipart_upload_days")
 		if abortAttr != nil {
-			abortBlock := tfwrite.NewEmptyNestedBlock("abort_incomplete_multipart_upload")
-			nestedBlock.AppendNestedBlock(abortBlock)
-			abortBlock.SetAttributeRaw("days_after_initiation", abortAttr.ValueAsTokens())
+			abort, err := abortAttr.ValueAsString()
+			// When the value is 0, adding a block will result in a migration plan diff,
+			// so suppress adding the block.
+			if err == nil && abort != "0" {
+				abortBlock := tfwrite.NewEmptyNestedBlock("abort_incomplete_multipart_upload")
+				nestedBlock.AppendNestedBlock(abortBlock)
+				abortBlock.SetAttributeRaw("days_after_initiation", abortAttr.ValueAsTokens())
+			}
 			nestedBlock.RemoveAttribute("abort_incomplete_multipart_upload_days")
 		}
 

--- a/filter/awsv4upgrade/aws_s3_bucket_lifecycle_rule_test.go
+++ b/filter/awsv4upgrade/aws_s3_bucket_lifecycle_rule_test.go
@@ -346,6 +346,40 @@ resource "aws_s3_bucket_lifecycle_configuration" "example" {
 `,
 		},
 		{
+			name: "with abort_incomplete_multipart_upload_days = 0",
+			src: `
+resource "aws_s3_bucket" "example" {
+  bucket = "tfedit-test"
+
+  lifecycle_rule {
+    id      = "rule-0"
+    enabled = true
+    abort_incomplete_multipart_upload_days = 0
+  }
+}
+`,
+			ok: true,
+			want: `
+resource "aws_s3_bucket" "example" {
+  bucket = "tfedit-test"
+
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "example" {
+  bucket = aws_s3_bucket.example.id
+
+  rule {
+    id     = "rule-0"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+  }
+}
+`,
+		},
+		{
 			name: "argument not found",
 			src: `
 resource "aws_s3_bucket" "example" {


### PR DESCRIPTION
Fixes #34

When the value is 0, adding a block will result in a migration plan diff, so suppress adding the block.