### PR TITLE
Use a native cache feature in actions/setup-go

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: '.go-version'
+        cache: true
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: '.go-version'
+        cache: true
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,12 +26,7 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: '.go-version'
-    - uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        cache: true
     - name: test
       run: make test
   testacc:


### PR DESCRIPTION
The actions/setup-go has a native cache feature.
There is no need to use actions/cache.