### PR TITLE
Rename s3_force_path_style to s3_use_path_style in provider aws block

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,6 @@ ENV TFUPDATE_VERSION 0.6.5
 RUN curl -fsSL https://github.com/minamijoyo/tfupdate/releases/download/v${TFUPDATE_VERSION}/tfupdate_${TFUPDATE_VERSION}_linux_amd64.tar.gz \
   | tar -xzC /usr/local/bin && chmod +x /usr/local/bin/tfupdate
 
-# Install hcledit
-ENV HCLEDIT_VERSION 0.2.5
-RUN curl -fsSL https://github.com/minamijoyo/hcledit/releases/download/v${HCLEDIT_VERSION}/hcledit_${HCLEDIT_VERSION}_linux_amd64.tar.gz \
-  | tar -xzC /usr/local/bin && chmod +x /usr/local/bin/hcledit
-
 # Install tfmigrate
 ENV TFMIGRATE_VERSION 0.3.3
 RUN curl -fsSL https://github.com/minamijoyo/tfmigrate/releases/download/v${TFMIGRATE_VERSION}/tfmigrate_${TFMIGRATE_VERSION}_linux_amd64.tar.gz \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Easy refactoring Terraform configurations in a scalable way.
 - CLI-friendly: Read HCL from stdin, apply filters and write results to stdout, easily pipe and combine other commands.
 - Keep comments: Update lots of existing Terraform configurations without losing comments as much as possible.
 - Built-in operations:
-  - filter awsv4upgrade: Upgrade configurations to AWS provider v4. Only `aws_s3_bucket` refactor is supported.
+  - filter awsv4upgrade: Upgrade configurations to AWS provider v4.
 - Generate a migration file for state operations: Read a Terraform plan file in JSON format and generate a migration file in [tfmigrate](https://github.com/minamijoyo/tfmigrate) HCL format. Currently, only import actions required by awsv4upgrade are supported.
 
 Although the initial goal of this project is providing a way for bulk refactoring of the `aws_s3_bucket` resource required by breaking changes in AWS provider v4, but the project scope is not limited to specific use-cases. It's by no means intended to be an upgrade tool for all your providers. Instead of covering all you need, it provides reusable building blocks for Terraform refactoring and shows examples for how to compose them in real world use-cases.
@@ -110,6 +110,11 @@ For upgrading AWS provider v4, some rules have not been implemented yet. The cur
 - [ ] Rename references in an expression to new resource type
 - [x] Generate import commands for new split resources
 
+[New Provider Arguments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#new-provider-arguments)
+
+- [ ] Arguments of provider aws
+  - [x] s3_force_path_style
+
 ### Known limitations:
 - Some arguments were changed not only their names but also valid values. In this case, if a value of the argument is a variable, not literal, it's impossible to automatically rewrite the value of the variable. It potentially could be passed from outside of module or even overwritten at runtime. If it's not literal, you need to change the value of the variable by yourself. The following arguments have this limitation:
   - grant:
@@ -190,13 +195,6 @@ Then, let's upgrade the AWS provider to the latest v4.x. We recommend upgrading 
 Terraform v1.1.8
 on linux_amd64
 + provider registry.terraform.io/hashicorp/aws v4.9.0
-```
-
-One thing to note is that the `s3_force_path_style` attribute in the `provider "aws"` block has been renamed to a new `s3_use_path_style` attribute in v4, so rename it with [hcledit](https://github.com/minamijoyo/hcledit). This is an issue in the sandbox environment and this step is not needed in a real AWS environment:
-
-```
-# hcledit attribute rm -u -f config.tf provider.aws.s3_force_path_style
-# hcledit attribute append -u -f config.tf provider.aws.s3_use_path_style true
 ```
 
 You can see a deprecation warning as follows:
@@ -389,7 +387,6 @@ $ tfedit filter awsv4upgrade --help
 Apply a built-in filter for awsv4upgrade
 
 Upgrade configurations to AWS provider v4.
-Only aws_s3_bucket refactor is supported.
 
 Usage:
   tfedit filter awsv4upgrade [flags]

--- a/cmd/filter.go
+++ b/cmd/filter.go
@@ -42,7 +42,6 @@ func newFilterAwsv4upgradeCmd() *cobra.Command {
 		Long: `Apply a built-in filter for awsv4upgrade
 
 Upgrade configurations to AWS provider v4.
-Only aws_s3_bucket refactor is supported.
 `,
 		RunE: runFilterAwsv4upgradeCmd,
 	}

--- a/filter/awsv4upgrade/all.go
+++ b/filter/awsv4upgrade/all.go
@@ -19,9 +19,9 @@ func NewAllFilter() editor.Filter {
 }
 
 // Filter upgrades configurations to AWS provider v4.
-// Only aws_s3_bucket refactor is supported.
 func (f *AllFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
 	m := editor.NewMultiFilter([]editor.Filter{
+		NewProviderAWSFilter(),
 		NewAWSS3BucketFilter(),
 	})
 	return m.Filter(inFile)

--- a/filter/awsv4upgrade/provider_aws.go
+++ b/filter/awsv4upgrade/provider_aws.go
@@ -1,0 +1,39 @@
+package awsv4upgrade
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/minamijoyo/hcledit/editor"
+	"github.com/minamijoyo/tfedit/tfeditor"
+	"github.com/minamijoyo/tfedit/tfwrite"
+)
+
+// ProviderAWSFilter is a filter implementation for upgrading arguments of
+// provider aws block to v4.
+// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#new-provider-arguments
+type ProviderAWSFilter struct {
+	filters []tfeditor.ProviderFilter
+}
+
+var _ editor.Filter = (*ProviderAWSFilter)(nil)
+
+// NewProviderAWSFilter creates a new instance of ProviderAWSFilter.
+func NewProviderAWSFilter() editor.Filter {
+	filters := []tfeditor.ProviderFilter{
+		&ProviderAWSS3ForcePathStyleFilter{},
+	}
+	return &ProviderAWSFilter{filters: filters}
+}
+
+// Filter upgrades arguments of provider aws block to v4.
+// Some rules have not been implemented yet.
+func (f *ProviderAWSFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
+	m := tfeditor.NewProvidersByTypeFilter("aws", f)
+	return m.Filter(inFile)
+}
+
+// ProviderFilter upgrades arguments of provider aws block to v4.
+// Some rules have not been implemented yet.
+func (f *ProviderAWSFilter) ProviderFilter(inFile *tfwrite.File, provider *tfwrite.Provider) (*tfwrite.File, error) {
+	m := tfeditor.NewMultiProviderFilter(f.filters)
+	return m.ProviderFilter(inFile, provider)
+}

--- a/filter/awsv4upgrade/provider_aws_s3_force_path_style.go
+++ b/filter/awsv4upgrade/provider_aws_s3_force_path_style.go
@@ -1,0 +1,35 @@
+package awsv4upgrade
+
+import (
+	"github.com/minamijoyo/tfedit/tfeditor"
+	"github.com/minamijoyo/tfedit/tfwrite"
+)
+
+// ProviderAWSS3ForcePathStyleFilter is a filter implementation for upgrading
+// the s3_force_path_style argument of provider aws block.
+// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3_use_path_style
+type ProviderAWSS3ForcePathStyleFilter struct{}
+
+var _ tfeditor.ProviderFilter = (*ProviderAWSS3ForcePathStyleFilter)(nil)
+
+// NewProviderAWSS3ForcePathStyleFilter creates a new instance of
+// ProviderAWSS3ForcePathStyleFilter.
+func NewProviderAWSS3ForcePathStyleFilter() tfeditor.ProviderFilter {
+	return &ProviderAWSS3ForcePathStyleFilter{}
+}
+
+// ProviderFilter is a filter implementation for upgrading the
+// s3_force_path_style argument of provider aws block.
+func (f *ProviderAWSS3ForcePathStyleFilter) ProviderFilter(inFile *tfwrite.File, provider *tfwrite.Provider) (*tfwrite.File, error) {
+	oldAttribute := "s3_force_path_style"
+	newAttribute := "s3_use_path_style"
+
+	// Rename a s3_force_path_style attribute to s3_use_path_style.
+	attr := provider.GetAttribute(oldAttribute)
+	if attr != nil {
+		provider.SetAttributeRaw(newAttribute, attr.ValueAsTokens())
+		provider.RemoveAttribute(oldAttribute)
+	}
+
+	return inFile, nil
+}

--- a/filter/awsv4upgrade/provider_aws_s3_force_path_style_test.go
+++ b/filter/awsv4upgrade/provider_aws_s3_force_path_style_test.go
@@ -1,0 +1,67 @@
+package awsv4upgrade
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/minamijoyo/hcledit/editor"
+	"github.com/minamijoyo/tfedit/tfeditor"
+)
+
+func TestProviderAWSS3ForcePathStyleFilter(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		ok   bool
+		want string
+	}{
+		{
+			name: "simple",
+			src: `
+provider "aws" {
+  s3_force_path_style = true
+}
+`,
+			ok: true,
+			want: `
+provider "aws" {
+  s3_use_path_style = true
+}
+`,
+		},
+		{
+			name: "argument not found",
+			src: `
+provider "aws" {
+  region = "ap-northeast-1"
+}
+`,
+			ok: true,
+			want: `
+provider "aws" {
+  region = "ap-northeast-1"
+}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := &ProviderAWSFilter{filters: []tfeditor.ProviderFilter{&ProviderAWSS3ForcePathStyleFilter{}}}
+			o := editor.NewEditOperator(filter)
+			output, err := o.Apply([]byte(tc.src), "test")
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := string(output)
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Fatalf("got:\n%s\nwant:\n%s\ndiff:\n%s", got, tc.want, diff)
+			}
+		})
+	}
+}

--- a/filter/awsv4upgrade/provider_aws_test.go
+++ b/filter/awsv4upgrade/provider_aws_test.go
@@ -1,0 +1,138 @@
+package awsv4upgrade
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/minamijoyo/hcledit/editor"
+)
+
+func TestProviderAWSFilter(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		ok   bool
+		want string
+	}{
+		{
+			name: "simple",
+			src: `
+provider "aws" {
+  region = "ap-northeast-1"
+
+  access_key                  = "dummy"
+  secret_key                  = "dummy"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+
+  # mock endpoints with localstack
+  endpoints {
+    s3 = "http://localstack:4566"
+  }
+
+  s3_force_path_style = true
+}
+`,
+			ok: true,
+			want: `
+provider "aws" {
+  region = "ap-northeast-1"
+
+  access_key                  = "dummy"
+  secret_key                  = "dummy"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+
+  # mock endpoints with localstack
+  endpoints {
+    s3 = "http://localstack:4566"
+  }
+
+  s3_use_path_style = true
+}
+`,
+		},
+		{
+			name: "multiple providers",
+			src: `
+provider "aws" {
+  alias = "foo"
+
+  s3_force_path_style = true
+}
+
+provider "aws" {
+  alias = "bar"
+
+  s3_force_path_style = true
+}
+`,
+			ok: true,
+			want: `
+provider "aws" {
+  alias = "foo"
+
+  s3_use_path_style = true
+}
+
+provider "aws" {
+  alias = "bar"
+
+  s3_use_path_style = true
+}
+`,
+		},
+		{
+			name: "argument not found",
+			src: `
+provider "aws" {
+  alias = "foo"
+}
+`,
+			ok: true,
+			want: `
+provider "aws" {
+  alias = "foo"
+}
+`,
+		},
+		{
+			name: "provider type not found",
+			src: `
+provider "google" {
+  alias = "foo"
+}
+`,
+			ok: true,
+			want: `
+provider "google" {
+  alias = "foo"
+}
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := NewProviderAWSFilter()
+			o := editor.NewEditOperator(filter)
+			output, err := o.Apply([]byte(tc.src), "test")
+			if tc.ok && err != nil {
+				t.Fatalf("unexpected err = %s", err)
+			}
+
+			got := string(output)
+			if !tc.ok && err == nil {
+				t.Fatalf("expected to return an error, but no error, outStream: \n%s", got)
+			}
+
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Fatalf("got:\n%s\nwant:\n%s\ndiff:\n%s", got, tc.want, diff)
+			}
+		})
+	}
+}

--- a/scripts/testacc/awsv4upgrade.sh
+++ b/scripts/testacc/awsv4upgrade.sh
@@ -28,10 +28,6 @@ upgrade()
   tfupdate provider aws -v "~> 4.9" .
   terraform init -input=false -no-color -upgrade
   terraform -v
-
-  # fix path style for sandbox only
-  hcledit attribute rm -u -f config.tf provider.aws.s3_force_path_style
-  hcledit attribute append -u -f config.tf provider.aws.s3_use_path_style true
 }
 
 filter()

--- a/tfeditor/filter_provider.go
+++ b/tfeditor/filter_provider.go
@@ -1,0 +1,74 @@
+package tfeditor
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/minamijoyo/hcledit/editor"
+	"github.com/minamijoyo/tfedit/tfwrite"
+)
+
+// ProviderFilter is an interface which reads Terraform configuration and
+// rewrite a given provider, and writes Terraform configuration.
+type ProviderFilter interface {
+	// ProviderFilter reads Terraform configuration and rewrite a given provider,
+	// and writes Terraform configuration.
+	ProviderFilter(*tfwrite.File, *tfwrite.Provider) (*tfwrite.File, error)
+}
+
+// MultiProviderFilter is a ProviderFilter implementation which applies
+// multiple provider filters to a given provider in sequence.
+type MultiProviderFilter struct {
+	filters []ProviderFilter
+}
+
+var _ ProviderFilter = (*MultiProviderFilter)(nil)
+
+// NewMultiProviderFilter creates a new instance of MultiProviderFilter.
+func NewMultiProviderFilter(filters []ProviderFilter) ProviderFilter {
+	return &MultiProviderFilter{
+		filters: filters,
+	}
+}
+
+// ProviderFilter applies multiple filters to a given provider in sequence.
+func (f *MultiProviderFilter) ProviderFilter(inFile *tfwrite.File, provider *tfwrite.Provider) (*tfwrite.File, error) {
+	current := inFile
+	for _, f := range f.filters {
+		next, err := f.ProviderFilter(current, provider)
+		if err != nil {
+			return nil, err
+		}
+		current = next
+	}
+	return current, nil
+}
+
+// ProvidersByTypeFilter is a Filter implementation for applying a filter to
+// multiple providers with a given provider type.
+type ProvidersByTypeFilter struct {
+	providerType string
+	filter       ProviderFilter
+}
+
+var _ editor.Filter = (*ProvidersByTypeFilter)(nil)
+
+// NewProvidersByTypeFilter creates a new instance of ProvidersByTypeFilter.
+func NewProvidersByTypeFilter(providerType string, filter ProviderFilter) editor.Filter {
+	return &ProvidersByTypeFilter{
+		providerType: providerType,
+		filter:       filter,
+	}
+}
+
+// Filter applies a filter to multiple providers with a given provider type.
+func (f *ProvidersByTypeFilter) Filter(inFile *hclwrite.File) (*hclwrite.File, error) {
+	current := tfwrite.NewFile(inFile)
+	providers := current.FindProvidersByType(f.providerType)
+	for _, provider := range providers {
+		next, err := f.filter.ProviderFilter(current, provider)
+		if err != nil {
+			return nil, err
+		}
+		current = next
+	}
+	return current.Raw(), nil
+}

--- a/tfwrite/file.go
+++ b/tfwrite/file.go
@@ -45,9 +45,38 @@ func (f *File) FindResourcesByType(resourceType string) []*Resource {
 	return matched
 }
 
+// FindProvidersByType returns all matching providers from the body that have the
+// given providerType or returns an empty list if not found.
+func (f *File) FindProvidersByType(providerType string) []*Provider {
+	var matched []*Provider
+
+	for _, block := range f.raw.Body().Blocks() {
+		if block.Type() != "provider" {
+			continue
+		}
+
+		labels := block.Labels()
+		if len(labels) == 1 && labels[0] != providerType {
+			continue
+		}
+
+		provider := NewProvider(block)
+		matched = append(matched, provider)
+	}
+
+	return matched
+}
+
 // AppendResource appends a given resource to the file.
 func (f *File) AppendResource(resource *Resource) {
 	body := f.raw.Body()
 	body.AppendNewline()
 	body.AppendBlock(resource.raw)
+}
+
+// AppendProvider appends a given provider to the file.
+func (f *File) AppendProvider(provider *Provider) {
+	body := f.raw.Body()
+	body.AppendNewline()
+	body.AppendBlock(provider.raw)
 }

--- a/tfwrite/file_test.go
+++ b/tfwrite/file_test.go
@@ -50,6 +50,65 @@ resource "foo_test" "example2" {}
 	}
 }
 
+func TestFileFindProvidersByType(t *testing.T) {
+	cases := []struct {
+		desc         string
+		src          string
+		providerType string
+		want         string
+		ok           bool
+	}{
+		{
+			desc: "simple",
+			src: `
+provider "aws" {
+  region = "ap-northeast-1"
+  alias  = "ap_northeast_1"
+}
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us_east_1"
+}
+
+provider "google" {}
+
+resource "aws_s3_bucket" "example" {}
+`,
+			providerType: "aws",
+			want: `
+provider "aws" {
+  region = "ap-northeast-1"
+  alias  = "ap_northeast_1"
+}
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us_east_1"
+}
+`,
+			ok: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			providers := f.FindProvidersByType(tc.providerType)
+
+			newFile := NewEmptyFile()
+			for _, p := range providers {
+				newFile.AppendProvider(p)
+			}
+
+			got := printTestFile(t, newFile)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Fatalf("got:\n%s\nwant:\n%s\ndiff:\n%s", got, tc.want, diff)
+			}
+		})
+	}
+}
+
 func TestFileAppendResource(t *testing.T) {
 	cases := []struct {
 		desc         string
@@ -81,6 +140,44 @@ resource "foo_test" "example2" {
 			f := parseTestFile(t, tc.src)
 			r := NewEmptyResource(tc.resourceType, tc.resourceName)
 			f.AppendResource(r)
+
+			got := printTestFile(t, f)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Fatalf("got:\n%s\nwant:\n%s\ndiff:\n%s", got, tc.want, diff)
+			}
+		})
+	}
+}
+
+func TestFileAppendProvider(t *testing.T) {
+	cases := []struct {
+		desc         string
+		src          string
+		providerType string
+		want         string
+		ok           bool
+	}{
+		{
+			desc: "simple",
+			src: `
+provider "aws" {}
+`,
+			providerType: "google",
+			want: `
+provider "aws" {}
+
+provider "google" {
+}
+`,
+			ok: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			p := NewEmptyProvider(tc.providerType)
+			f.AppendProvider(p)
 
 			got := printTestFile(t, f)
 			if diff := cmp.Diff(got, tc.want); diff != "" {

--- a/tfwrite/helper_test.go
+++ b/tfwrite/helper_test.go
@@ -48,6 +48,21 @@ func findTestBlocks(t *testing.T, f *File) []*block {
 // findFirstTestResource is a test helper for find the first resource.
 func findFirstTestResource(t *testing.T, f *File) *Resource {
 	t.Helper()
-	blocks := f.Raw().Body().Blocks()
-	return NewResource(blocks[0])
+	for _, block := range f.raw.Body().Blocks() {
+		if block.Type() == "resource" {
+			return NewResource(block)
+		}
+	}
+	return nil
+}
+
+// findFirstTestProvider is a test helper for find the first provider.
+func findFirstTestProvider(t *testing.T, f *File) *Provider {
+	t.Helper()
+	for _, block := range f.raw.Body().Blocks() {
+		if block.Type() == "provider" {
+			return NewProvider(block)
+		}
+	}
+	return nil
 }

--- a/tfwrite/provider.go
+++ b/tfwrite/provider.go
@@ -1,0 +1,33 @@
+package tfwrite
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Provider represents a provider block.
+// It implements the Block interface.
+type Provider struct {
+	*block
+}
+
+var _ Block = (*Provider)(nil)
+
+// NewProvider creates a new instance of Provider.
+func NewProvider(block *hclwrite.Block) *Provider {
+	b := newBlock(block)
+	return &Provider{block: b}
+}
+
+// NewEmptyProvider creates a new Provider with an empty body.
+func NewEmptyProvider(providerType string) *Provider {
+	block := hclwrite.NewBlock("provider", []string{providerType})
+	return NewProvider(block)
+}
+
+// SchemaType returns a type of provider.
+// It returns the first label of block.
+// Note that it's not the same as the *hclwrite.Block.Type().
+func (p *Provider) SchemaType() string {
+	labels := p.block.raw.Labels()
+	return labels[0]
+}

--- a/tfwrite/provider_test.go
+++ b/tfwrite/provider_test.go
@@ -1,0 +1,64 @@
+package tfwrite
+
+import (
+	"testing"
+)
+
+func TestProviderType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+provider "foo"{}
+`,
+			want: "provider",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			p := findFirstTestProvider(t, f)
+
+			got := p.Type()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProviderSchemaType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+provider "foo"{}
+`,
+			want: "foo",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			p := findFirstTestProvider(t, f)
+			got := p.SchemaType()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3_use_path_style

This attribute is only needed when mocking for testing, so we are currently depending on the hcledit CLI for acceptance testing. We can remove it by adding a rewrite rule as a filter.

This is also an experiment extending the filter beyond the resource block as a refactoring library.