### PR TITLE
Complete all primitive top-level block types

### DIFF
--- a/tfwrite/file.go
+++ b/tfwrite/file.go
@@ -32,6 +32,18 @@ func parseBlock(block *hclwrite.Block) Block {
 		return NewDataSource(block)
 	case "provider":
 		return NewProvider(block)
+	case "variable":
+		return NewVariable(block)
+	case "output":
+		return NewOutput(block)
+	case "locals":
+		return NewLocals(block)
+	case "module":
+		return NewModule(block)
+	case "terraform":
+		return NewTerraform(block)
+	case "moved":
+		return NewMoved(block)
 	default:
 		return newBlock(block) // unknown
 	}

--- a/tfwrite/locals.go
+++ b/tfwrite/locals.go
@@ -1,0 +1,25 @@
+package tfwrite
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Locals represents a locals block.
+// It implements the Block interface.
+type Locals struct {
+	*block
+}
+
+var _ Block = (*Locals)(nil)
+
+// NewLocals creates a new instance of Locals.
+func NewLocals(block *hclwrite.Block) *Locals {
+	b := newBlock(block)
+	return &Locals{block: b}
+}
+
+// NewEmptyLocals creates a new Locals with an empty body.
+func NewEmptyLocals() *Locals {
+	block := hclwrite.NewBlock("locals", []string{})
+	return NewLocals(block)
+}

--- a/tfwrite/locals_test.go
+++ b/tfwrite/locals_test.go
@@ -1,0 +1,64 @@
+package tfwrite
+
+import (
+	"testing"
+)
+
+func TestLocalsType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+locals {}
+`,
+			want: "locals",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewLocals(findFirstTestBlock(t, f).Raw())
+
+			got := b.Type()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLocalsSchemaType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+locals {}
+`,
+			want: "",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewLocals(findFirstTestBlock(t, f).Raw())
+			got := b.SchemaType()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/tfwrite/module.go
+++ b/tfwrite/module.go
@@ -1,0 +1,25 @@
+package tfwrite
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Module represents a module block.
+// It implements the Block interface.
+type Module struct {
+	*block
+}
+
+var _ Block = (*Module)(nil)
+
+// NewModule creates a new instance of Module.
+func NewModule(block *hclwrite.Block) *Module {
+	b := newBlock(block)
+	return &Module{block: b}
+}
+
+// NewEmptyModule creates a new Module with an empty body.
+func NewEmptyModule(moduleType string) *Module {
+	block := hclwrite.NewBlock("module", []string{moduleType})
+	return NewModule(block)
+}

--- a/tfwrite/module_test.go
+++ b/tfwrite/module_test.go
@@ -1,0 +1,64 @@
+package tfwrite
+
+import (
+	"testing"
+)
+
+func TestModuleType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+module "foo" {}
+`,
+			want: "module",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewModule(findFirstTestBlock(t, f).Raw())
+
+			got := b.Type()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModuleSchemaType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+module "foo" {}
+`,
+			want: "foo",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewModule(findFirstTestBlock(t, f).Raw())
+			got := b.SchemaType()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/tfwrite/moved.go
+++ b/tfwrite/moved.go
@@ -1,0 +1,25 @@
+package tfwrite
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Moved represents a moved block.
+// It implements the Block interface.
+type Moved struct {
+	*block
+}
+
+var _ Block = (*Moved)(nil)
+
+// NewMoved creates a new instance of Moved.
+func NewMoved(block *hclwrite.Block) *Moved {
+	b := newBlock(block)
+	return &Moved{block: b}
+}
+
+// NewEmptyMoved creates a new Moved with an empty body.
+func NewEmptyMoved() *Moved {
+	block := hclwrite.NewBlock("moved", []string{})
+	return NewMoved(block)
+}

--- a/tfwrite/moved_test.go
+++ b/tfwrite/moved_test.go
@@ -1,0 +1,64 @@
+package tfwrite
+
+import (
+	"testing"
+)
+
+func TestMovedType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+moved {}
+`,
+			want: "moved",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewMoved(findFirstTestBlock(t, f).Raw())
+
+			got := b.Type()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMovedSchemaType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+moved {}
+`,
+			want: "",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewMoved(findFirstTestBlock(t, f).Raw())
+			got := b.SchemaType()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/tfwrite/output.go
+++ b/tfwrite/output.go
@@ -1,0 +1,25 @@
+package tfwrite
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Output represents a output block.
+// It implements the Block interface.
+type Output struct {
+	*block
+}
+
+var _ Block = (*Output)(nil)
+
+// NewOutput creates a new instance of Output.
+func NewOutput(block *hclwrite.Block) *Output {
+	b := newBlock(block)
+	return &Output{block: b}
+}
+
+// NewEmptyOutput creates a new Output with an empty body.
+func NewEmptyOutput(outputType string) *Output {
+	block := hclwrite.NewBlock("output", []string{outputType})
+	return NewOutput(block)
+}

--- a/tfwrite/output_test.go
+++ b/tfwrite/output_test.go
@@ -1,0 +1,64 @@
+package tfwrite
+
+import (
+	"testing"
+)
+
+func TestOutputType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+output "foo" {}
+`,
+			want: "output",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewOutput(findFirstTestBlock(t, f).Raw())
+
+			got := b.Type()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOutputSchemaType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+output "foo" {}
+`,
+			want: "foo",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewOutput(findFirstTestBlock(t, f).Raw())
+			got := b.SchemaType()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/tfwrite/terraform.go
+++ b/tfwrite/terraform.go
@@ -1,0 +1,25 @@
+package tfwrite
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Terraform represents a terraform block.
+// It implements the Block interface.
+type Terraform struct {
+	*block
+}
+
+var _ Block = (*Terraform)(nil)
+
+// NewTerraform creates a new instance of Terraform.
+func NewTerraform(block *hclwrite.Block) *Terraform {
+	b := newBlock(block)
+	return &Terraform{block: b}
+}
+
+// NewEmptyTerraform creates a new Terraform with an empty body.
+func NewEmptyTerraform() *Terraform {
+	block := hclwrite.NewBlock("terraform", []string{})
+	return NewTerraform(block)
+}

--- a/tfwrite/terraform_test.go
+++ b/tfwrite/terraform_test.go
@@ -1,0 +1,64 @@
+package tfwrite
+
+import (
+	"testing"
+)
+
+func TestTerraformType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+terraform {}
+`,
+			want: "terraform",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewTerraform(findFirstTestBlock(t, f).Raw())
+
+			got := b.Type()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTerraformSchemaType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+terraform {}
+`,
+			want: "",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewTerraform(findFirstTestBlock(t, f).Raw())
+			got := b.SchemaType()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/tfwrite/variable.go
+++ b/tfwrite/variable.go
@@ -1,0 +1,25 @@
+package tfwrite
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Variable represents a variable block.
+// It implements the Block interface.
+type Variable struct {
+	*block
+}
+
+var _ Block = (*Variable)(nil)
+
+// NewVariable creates a new instance of Variable.
+func NewVariable(block *hclwrite.Block) *Variable {
+	b := newBlock(block)
+	return &Variable{block: b}
+}
+
+// NewEmptyVariable creates a new Variable with an empty body.
+func NewEmptyVariable(variableType string) *Variable {
+	block := hclwrite.NewBlock("variable", []string{variableType})
+	return NewVariable(block)
+}

--- a/tfwrite/variable_test.go
+++ b/tfwrite/variable_test.go
@@ -1,0 +1,64 @@
+package tfwrite
+
+import (
+	"testing"
+)
+
+func TestVariableType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+variable "foo" {}
+`,
+			want: "variable",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewVariable(findFirstTestBlock(t, f).Raw())
+
+			got := b.Type()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVariableSchemaType(t *testing.T) {
+	cases := []struct {
+		desc string
+		src  string
+		want string
+		ok   bool
+	}{
+		{
+			desc: "simple",
+			src: `
+variable "foo" {}
+`,
+			want: "foo",
+			ok:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f := parseTestFile(t, tc.src)
+			b := NewVariable(findFirstTestBlock(t, f).Raw())
+			got := b.SchemaType()
+			if got != tc.want {
+				t.Errorf("got = %s, but want = %s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add the following block types:

- variable
- output
- locals
- module
- terraform
- moved

It's just a type definition and no useful methods have been implemented yet, but it provides a good start point.